### PR TITLE
W-11382926: Flex Custom Policy Docs contains wrong example code

### DIFF
--- a/modules/ROOT/pages/policies-custom-flex-implement-rust.adoc
+++ b/modules/ROOT/pages/policies-custom-flex-implement-rust.adoc
@@ -245,7 +245,7 @@ Flex Gateway configures your policy with JSON defined in the policy definition. 
 . Implement the `on_configure` method of the `RootContext` trait to deserialize the configuration:
 +
 ----
-impl RootContext for HttpConfigHeaderRoot {
+impl RootContext for CustomAuthRootContext {
 
     fn on_configure(&mut self, _: usize) -> bool {
         if let Some(config_bytes) = self.get_plugin_configuration() {


### PR DESCRIPTION
# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
