### PR TITLE
W-11503788: version should be '1.1'

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: gateway
 title: Gateway
-version: master
+version: '1.1'
 asciidoc:
   attributes:
     gateway-ver-var: latest


### PR DESCRIPTION
Reference: [W-11503788](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000012PvofYAC/view)

This change is needed for v1.1 to properly build.

See https://github.com/mulesoft/docs-site-playbook/pull/951