### PR TITLE
Add page-alias to fix broken redirect.

### DIFF
--- a/gateway-home/modules/ROOT/pages/gateway-overview.adoc
+++ b/gateway-home/modules/ROOT/pages/gateway-overview.adoc
@@ -3,6 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
+:page-aliases: 1.1@gateway::flex-gateway-overview
 
 An API gateway allows you to add a dedicated orchestration layer on top of your backend APIs and services
 to help you separate orchestration from implementation concerns. You can then leverage the governance capabilities
@@ -88,4 +89,3 @@ For more information, see xref:service-mesh::getting-started-service-mesh.adoc[G
 // * Local file
 // * Anypoint Platform (for metering data)
 // * Sumo Logic
-


### PR DESCRIPTION
# Fix broken redirect


Based on [Slack feedback](https://salesforce-internal.slack.com/archives/C02HGAD2E/p1674442004580249), there's a Google result linking to a broken redirect to an old article of Flex Gateway.:

[W-12421702 - Broken redirect from Google result to Flex Gateway content](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001JumWcYAJ/view)

![image](https://user-images.githubusercontent.com/16763154/214082582-3456ee1d-683b-4105-82c1-6f57493a6d97.png)
![image (1)](https://user-images.githubusercontent.com/16763154/214082641-4305b8e6-dc94-4d98-8975-bd1eaa835ef2.png)


This page alias fixes this particular case, but docs-gateway also used to have a v1.0 page. Should we also add a redirect for that case?

```
:page-aliases: 1.1@gateway::flex-gateway-overview, 1.0@gateway::flex-gateway-overview.adoc
```