### PR TITLE
W-13465592: Footnotes #6 and #7 reversed?  (Also, what does "the Edge" refer to? Surely not the guitarist for the band U2)

### DIFF
--- a/policies/modules/ROOT/pages/policies-custom-mule-4-reference.adoc
+++ b/policies/modules/ROOT/pages/policies-custom-mule-4-reference.adoc
@@ -589,8 +589,8 @@ configuration:  // <11>
 <3> Deprecated property. Value should be set to ‘>=v1’ for now. Mandatory
 <4> Description of what the policy does. Also used in API Manager’s UI. Mandatory
 <5> Category to which the policy belongs. Used to group and filter policies in API Manager’s UI, any String value is valid. Mandatory
-<6> Deprecated property. Value should be set to ‘system’. Mandatory
-<7> Value used by the Edge to show metrics about different types of policy violations. Mandatory
+<6> Value used by the Edge to show metrics about different types of policy violations. Mandatory
+<7> Deprecated property. Value should be set to ‘system’. Mandatory
 <8> Whether resource level pointcuts should be enabled when applying the policy. Mandatory
 <9> Deprecated property. Value should be set to ‘true’. Mandatory
 <10> Whether policy requires information about an identity management that is configured to the API’s Organization. Optional


### PR DESCRIPTION
Footnotes for 6 and 7 seem to be reversed in the example yaml configuration... please research and verify.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
