### PR TITLE
Update header injection policy docs to match implementation

### DIFF
--- a/policies/modules/ROOT/pages/policies-included-header-injection.adoc
+++ b/policies/modules/ROOT/pages/policies-included-header-injection.adoc
@@ -48,10 +48,10 @@ In Local Mode, you apply the Header Injection policy to your API via declarative
     name: header-injection-flex
   config:
     inboundHeaders: <array> // OPTIONAL, default: []
-      - name: <string> // REQUIRED
+      - key: <string> // REQUIRED
         value: <string> // REQUIRED
     outboundHeaders: <array> // OPTIONAL, default: []
-      - name: <string> // REQUIRED
+      - key: <string> // REQUIRED
         value: <string> // REQUIRED
 ----
 
@@ -106,10 +106,10 @@ In the following example, all the headers matching the configured `#[attributes.
     name: header-injection-flex
     config:
       inboundHeaders:
-        - name: "new-inbound-header"
+        - key: "new-inbound-header"
           value: "#[attributes.requestPath]"
       outboundHeaders:
-        - name: "new-outbound-header"
+        - key: "new-outbound-header"
           value: "#[attributes.requestPath]"
 ----
 

--- a/policies/modules/ROOT/pages/policies-included-header-injection.adoc
+++ b/policies/modules/ROOT/pages/policies-included-header-injection.adoc
@@ -65,7 +65,7 @@ In Local Mode, you apply the Header Injection policy to your API via declarative
 | Empty array
 | List of headers to be injected at the beginning of the message processing.
 
-| `inboundHeaders.name` 
+| `inboundHeaders.key` 
 | Required
 | N/A
 | A string or DataWeave expression for header name
@@ -80,7 +80,7 @@ In Local Mode, you apply the Header Injection policy to your API via declarative
 | Empty array
 | List of header to be injected at the end of the message processing.
 
-| `outboundHeaders.name` 
+| `outboundHeaders.key` 
 | Required
 | N/A
 | A string or DataWeave expression for header name


### PR DESCRIPTION
This PRs
- Rename `name` to `key` which is expected for the `inboundHeaders` and `outboundHeaders` arrays for the documentation page at https://docs.mulesoft.com/policies/policies-included-header-injection

Using `name` for these values in Flex Gateway running in local mode, we get the error:

```
mulesoft-flex-gateway-gateway-1  | [flex-gateway-agent][error] Processing Command Error: PolicyBinding default/authorization-rewrite: is invalid (invalid config: property 'outboundHeaders': the element on the 0 position of the array failed due to property 'key': missing but it is required)
```

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
