### PR TITLE
W-13465620: Replace x-forwarded-for by a secure one

### DIFF
--- a/policies/modules/ROOT/pages/policies-included-ip-allowlist.adoc
+++ b/policies/modules/ROOT/pages/policies-included-ip-allowlist.adoc
@@ -34,7 +34,7 @@ In Local Mode, you apply the IP Allowlist policy to your API via declarative con
     name: ip-allowlist-flex
   config:
     ips: <array> // REQUIRED
-    ipExpression: <string> // OPTIONAL, default: "#[attributes.headers['x-forwarded-for']]"
+    ipExpression: <string> // OPTIONAL, default: "#[dw::core::Strings::substring(attributes.headers['x-forwarded-for'],((attributes.headers['x-forwarded-for'] lastIndexOf(" "))+1),255) default attributes.remoteAddress]"
 ----
 
 [%header%autowidth.spread,cols="a,a,a,a"]


### PR DESCRIPTION
"Last Mile" (=Dedicated-Loadbalancer / Ingress) adds the real IP as last one to the string x-forwarded-for.

#[dw::core::Strings::substring(attributes.headers['x-forwarded-for'],((attributes.headers['x-forwarded-for'] lastIndexOf(" "))+1),255) default attributes.remoteAddress]

extract the last one.
Example when using: CURL with  -H x-forwarded-for:1.2.3.4 1.2.3.4, 10.40.11.239

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
