### PR TITLE
[W-14792039] add start_page

### DIFF
--- a/pdk/1.0/antora.yml
+++ b/pdk/1.0/antora.yml
@@ -2,6 +2,7 @@ name: pdk
 title: 'Flex Gateway Policy Development Kit (PDK)'
 version: '1.0'
 display_version: '1.0'
+start_page: policies-pdk-overview.adoc
 asciidoc:
   attributes:
     rust-ver-var: 'v1.74.0'


### PR DESCRIPTION
this should fix the issue where https://docs.mulesoft.com/pdk/latest/ returns "404 not found" (because it is trying to look for the file _index.adoc_ which doesn't exist).

ref: https://docs.antora.org/antora/latest/component-start-page/