### PR TITLE
W-17564477 add docs for custom image names

### DIFF
--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -184,6 +184,21 @@ async fn say_hello() -> anyhow::Result<()> {
 
 NOTE: If the Docker engine is properly configured, this test passes. Run `make test` to ensure proper configuration.
 
+[[alternative-httpmock-docker-images]]
+=== Configure an alternative httpmock Docker image
+If you want to use an `httpmock` Docker image from another source instead of the one provided by default,
+the configuration builder provides an `image_name()` method  to define it explicitly:
+
+[source,rust]
+----
+// Configure HttpMock service
+let backend_config = HttpMockConfig::builder()
+    .image_name("myrepo/httpmock") // Custom image name setting
+    .hostname("backend")
+    .port(80)
+    .build();
+----
+
 [[get-a-services-hande]]
 === Get a Service's Handle
 
@@ -292,6 +307,9 @@ The `FlexConfig` struct has the following properties:
 |`version`
 |Flex Gateway version to test.
 
+|`image_name`
+|Flex Gateway Docker image name, by default, "mulesoft/flex-gateway".
+
 |`hostname`
 |Hostname of the `Flex` service, by default, "local-flex".
 
@@ -397,6 +415,27 @@ async fn say_hello() -> anyhow::Result<()> {
         .await?;
 }
 ----
+
+[[alternative-flex-docker-images]]
+=== Configure an alternative Flex Docker image
+If you want to use an `flex` Docker image from another source instead of the one provided by default,
+the configuration builder provides an `image_name()` method  to define it explicitly:
+
+[source,rust]
+----
+// Configure the Flex service
+let flex_config = FlexConfig::builder()
+    .image_name("myrepo/flex-gateway") // Custom image name setting
+    .version("1.6.1")
+    .hostname("local-flex")
+    .config_mounts([
+        (POLICY_DIR, "policy"),
+        (COMMON_CONFIG_DIR, "common")
+    ])
+    .with_api(api_config)
+    .build();
+----
+
 
 [NOTE] 
 ====

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -185,7 +185,7 @@ async fn say_hello() -> anyhow::Result<()> {
 NOTE: If the Docker engine is properly configured, this test passes. Run `make test` to ensure proper configuration.
 
 [[alternative-httpmock-docker-images]]
-=== Configure an Alternative httpmock Docker image
+=== Configure an Alternative httpmock Docker Image
 
 To use an `httpmock` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
 
@@ -419,7 +419,7 @@ async fn say_hello() -> anyhow::Result<()> {
 ----
 
 [[alternative-flex-docker-images]]
-=== Configure an alternative Flex Docker image
+=== Configure an Alternative Flex Docker Image
 
 To use a `flex` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
 

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -188,7 +188,8 @@ NOTE: If the Docker engine is properly configured, this test passes. Run `make t
 === Configure an Alternative httpmock Docker image
 
 To use an `httpmock` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
-Update your `HttpMockConfig::builder()` code as in the following example:
+
+To configure an alternative `httpmock` Docker image, update your your `HttpMockConfig::builder()` definition as in the following example:
 
 [source,rust]
 ----
@@ -421,7 +422,8 @@ async fn say_hello() -> anyhow::Result<()> {
 === Configure an alternative Flex Docker image
 
 To use a `flex` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
-Update your `FlexConfig::builder()` code as in the following example:
+
+To configure an alternative Flex Docker image, update your your `FlexConfig::builder()` definition as in the following example:
 
 [source,rust]
 ----

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -189,7 +189,7 @@ NOTE: If the Docker engine is properly configured, this test passes. Run `make t
 
 To use an `httpmock` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
 
-To configure an alternative `httpmock` Docker image, update your your `HttpMockConfig::builder()` definition as in the following example:
+To configure an alternative `httpmock` Docker image, update your your `HttpMockConfig::builder()` definition as in this example:
 
 [source,rust]
 ----

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -423,7 +423,7 @@ async fn say_hello() -> anyhow::Result<()> {
 
 To use a `flex` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
 
-To configure an alternative Flex Docker image, update your your `FlexConfig::builder()` definition as in the following example:
+To configure an alternative Flex Docker image, update your your `FlexConfig::builder()` definition as in this example:
 
 [source,rust]
 ----

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -419,6 +419,7 @@ async fn say_hello() -> anyhow::Result<()> {
 
 [[alternative-flex-docker-images]]
 === Configure an alternative Flex Docker image
+
 If you want to use an `flex` Docker image from another source instead of the one provided by default,
 the configuration builder provides an `image_name()` method  to define it explicitly:
 

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -146,7 +146,7 @@ PDK's test library supports the following services:
 | Flex Gateway service instance.
 
 | `httpmock`
-| Service binding to the Rust's https://crates.io/crates/httpmock:[httpmock] server.
+| Service binding to the Rust's https://crates.io/crates/httpmock[httpmock] server.
 |===
 
 The supported services cover the majority of use cases for integration testing. It is not possible to define different types of service.

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -152,7 +152,7 @@ PDK's test library supports the following services:
 The supported services cover the majority of use cases for integration testing. It is not possible to define different types of service.
 
 [[httpmock-service]]
-=== httpmock Service
+=== Configure an httpmock Service
 
 `httpmock` is a mock server that enables you to write request mocks in Rust. Configure an https://crates.io/crates/httpmock[httpmock^] service by using an `HttpMockConfig` value. It is a best practice to return a `Result` from the test function. The https://crates.io/crates/anyhow:[anyhow^] Rust crate enables you to return different default error types.
 
@@ -185,10 +185,10 @@ async fn say_hello() -> anyhow::Result<()> {
 NOTE: If the Docker engine is properly configured, this test passes. Run `make test` to ensure proper configuration.
 
 [[alternative-httpmock-docker-images]]
-=== Alternative httpmock Docker image
+=== Configure an Alternative httpmock Docker image
 
-To use an `httpmock` Docker image from another source, instead of the one provided by default,
-the configuration builder provides an `image_name()` method to define it explicitly. See the following example:
+To use an `httpmock` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
+Update your `HttpMockConfig::builder()` code as in the following example:
 
 [source,rust]
 ----
@@ -196,7 +196,7 @@ the configuration builder provides an `image_name()` method to define it explici
 let backend_config = HttpMockConfig::builder()
     .image_name("myrepo/httpmock") // Custom image name setting
     .hostname("backend")
-    .port(80)
+    .port(80) // Port where the service will accept requests
     .build();
 ----
 
@@ -420,8 +420,8 @@ async fn say_hello() -> anyhow::Result<()> {
 [[alternative-flex-docker-images]]
 === Configure an alternative Flex Docker image
 
-If you want to use an `flex` Docker image from another source instead of the one provided by default,
-the configuration builder provides an `image_name()` method  to define it explicitly:
+To use a `flex` Docker image from another source, instead of the provided default, the configuration builder provides an `image_name()` method to define it explicitly. 
+Update your `FlexConfig::builder()` code as in the following example:
 
 [source,rust]
 ----

--- a/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
+++ b/pdk/1.3/modules/ROOT/pages/policies-pdk-integration-tests.adoc
@@ -185,9 +185,10 @@ async fn say_hello() -> anyhow::Result<()> {
 NOTE: If the Docker engine is properly configured, this test passes. Run `make test` to ensure proper configuration.
 
 [[alternative-httpmock-docker-images]]
-=== Configure an alternative httpmock Docker image
-If you want to use an `httpmock` Docker image from another source instead of the one provided by default,
-the configuration builder provides an `image_name()` method  to define it explicitly:
+=== Alternative httpmock Docker image
+
+To use an `httpmock` Docker image from another source, instead of the one provided by default,
+the configuration builder provides an `image_name()` method to define it explicitly. See the following example:
 
 [source,rust]
 ----


### PR DESCRIPTION
Fixed a link to https://crates.io/crates/httpmock that had an extra trailing ":" character.
Made some case and wording changes to the update by @balbifm .