### PR TITLE
W-18685110 Fix error in maxObjectEntryCount and maxObjectEntryNameLength descriptions

### DIFF
--- a/gateway/1.9/modules/ROOT/pages/policies-included-json-threat-protection.adoc
+++ b/gateway/1.9/modules/ROOT/pages/policies-included-json-threat-protection.adoc
@@ -49,12 +49,12 @@ include::partial$policy-title-headers.adoc[tag=configFile]
 | `maxObjectEntryCount`
 | Optional
 | -1
-| Specifies the maximum string length of an object's entry name. Specifying -1 indicates that the field value has no limits.
+| Specifies the maximum number of entries in an object. Specifying -1 indicates that the field value has no limits.
 
 | `maxObjectEntryNameLength`
 | Optional
 | -1
-| Specifies the maximum number of entries in an object. Specifying -1 indicates that the field value has no limits.
+| Specifies the maximum string length of an object's entry name. Specifying -1 indicates that the field value has no limits.
 
 | `maxArrayElementCount`
 | Optional


### PR DESCRIPTION
# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
