### PR TITLE
W-23259890 fix stale Maven Facade v1 URL to v3

### DIFF
--- a/mule-gateway/modules/ROOT/pages/policies-custom-upload-to-exchange.adoc
+++ b/mule-gateway/modules/ROOT/pages/policies-custom-upload-to-exchange.adoc
@@ -64,7 +64,7 @@ To deploy a policy created without using the Maven archetype:
 [source,XML,linenums]
 --
 <properties>
-  <exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/{OrgId}/maven</exchange.url>
+  <exchange.url>https://maven.anypoint.mulesoft.com/api/v3/organizations/{OrgId}/maven</exchange.url>
   <mule.maven.plugin.version>3.2.0</mule.maven.plugin.version> <!-- check for last available version -->
 </properties>
 --


### PR DESCRIPTION
Update policies-custom-upload-to-exchange.adoc code sample to use the current Maven Facade API version. The v1 endpoint is stale; docs-exchange canonical publishing docs use /api/v3/ for the standard region.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
