### PR TITLE
Rename Flex Gateway to Omni Gateway in gateway/1.13 metadata and content

### DIFF
--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-agent-card.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-agent-card.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-pii-detector.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-pii-detector.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-prompt-decorator.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-prompt-decorator.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-to-v03-transcoder.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-to-v03-transcoder.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-token-rate-limit.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-token-rate-limit.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, rate limiting, token, a2a
+:keywords: api gateway, omni gateway, gateway, policy, rate limiting, token, a2a
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-agent-card.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-agent-card.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-pii-detector.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-pii-detector.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-prompt-decorator.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-prompt-decorator.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-to-v03-transcoder.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-to-v03-transcoder.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-token-rate-limit.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-a2a-v1-token-rate-limit.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-agent-connection-telemetry.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-agent-connection-telemetry.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, agent, telemetry, agent connection, A2A, MCP
+:keywords: api gateway, omni gateway, gateway, policy, agent, telemetry, agent connection, A2A, MCP
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-azure-content-safety.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-azure-content-safety.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, llm, content safety, azure, guardrails, harm detection
+:keywords: api gateway, omni gateway, gateway, policy, llm, content safety, azure, guardrails, harm detection
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-basic-auth-ldap.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-basic-auth-ldap.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, ldap, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, ldap, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::basic-authentication-ldap-concept.adoc, policies::policies-included-basic-auth-ldap.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-basic-auth-simple.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-basic-auth-simple.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::basic-authentication-simple-concept.adoc, api-manager::basic-authentication-concept.adoc, api-manager::http-basic-authentication-policy.adoc, policies::policies-included-basic-auth-simple.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-bedrock-guardrails.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-bedrock-guardrails.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, llm, bedrock, guardrails, content safety, pii
+:keywords: api gateway, omni gateway, gateway, policy, llm, bedrock, guardrails, content safety, pii
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-client-id-enforcement.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-client-id-enforcement.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: clientid enforcement, api gateway, flex gateway, gateway, policy
+:keywords: clientid enforcement, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::client-id-based-policies.adoc, policies::policies-included-client-id-enforcement.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-cors.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-cors.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: cross origin resource sharing, cors, api gateway, flex gateway, gateway, policy
+:keywords: cross origin resource sharing, cors, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::cors-policy.adoc, api-manager::avoid-restrictions-task.adoc, api-manager::cors-mule4.adoc, api-manager::cors-reference.adoc, policies::policies-included-cors.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-body-transformation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-body-transformation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: dataweave, body transformation, transformation, api gateway, flex gateway, gateway, policy
+:keywords: dataweave, body transformation, transformation, api gateway, omni gateway, gateway, policy
 
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-headers-transformation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-headers-transformation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: dataweave, headers transformation, transformation, api gateway, flex gateway, gateway, policy
+:keywords: dataweave, headers transformation, transformation, api gateway, omni gateway, gateway, policy
 
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-request-filter.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-dataweave-request-filter.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: dataweave, request filter, transformation, api gateway, flex gateway, gateway, policy
+:keywords: dataweave, request filter, transformation, api gateway, omni gateway, gateway, policy
 
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-external-authorization.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-external-authorization.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: external authorization, authorization, flex gateway, gateway, policy
+:keywords: external authorization, authorization, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-external-processing.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-external-processing.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: external processing, processing, flex gateway, gateway, policy
+:keywords: external processing, processing, omni gateway, gateway, policy
 
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-graphql-introspection-control.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-graphql-introspection-control.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: graphql, introspection, api gateway, flex gateway, gateway, policy
+:keywords: graphql, introspection, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-graphql-operation-limits.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-graphql-operation-limits.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: graphql, operation limits, api gateway, flex gateway, gateway, policy
+:keywords: graphql, operation limits, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-graphql-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-graphql-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: graphql, schema validation, api gateway, flex gateway, gateway, policy
+:keywords: graphql, schema validation, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===
@@ -22,7 +22,7 @@ The GraphQL Schema Validation policy applies standard GraphQL validation rules, 
 
 The policy loads the schema in these ways:
 
-* If `source` is `context`, Flex Gateway automatically loads the schema file from the API asset in Anypoint Exchange.
+* If `source` is `context`, Omni Gateway automatically loads the schema file from the API asset in Anypoint Exchange.
 * If `source` is `inline`, provide the schema text directly in the policy configuration. This is required for local mode or environments not connected to Exchange.
 
 If the document includes an `@link` to the Apollo Federation specification URL, Omni Gateway uses this schema to validate all incoming requests.

--- a/gateway/1.13/modules/ROOT/pages/policies-included-graphql-static-query-complexity.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-graphql-static-query-complexity.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: graphql, query complexity, api gateway, flex gateway, gateway, policy
+:keywords: graphql, query complexity, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-header-injection.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-header-injection.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: header injection, api gateway, flex gateway, gateway, policy
+:keywords: header injection, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::header-injection-policy.adoc, general::header-inject-remove-task.adoc, policies::policies-included-header-injection.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-header-removal.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-header-removal.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: header removal, api gateway, flex gateway, gateway, policy
+:keywords: header removal, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::header-removal-policy.adoc, policies::policies-included-header-removal.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-health-check.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-health-check.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: health check, api gateway, flex gateway, gateway, policy
+:keywords: health check, api gateway, omni gateway, gateway, policy
 :page-aliases: policies::policies-included-health-check.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-http-caching.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-http-caching.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: http caching, api gateway, flex gateway, gateway, policy
+:keywords: http caching, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::http-caching-policy.adoc, policies::policies-included-http-caching.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-injection-protection.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-injection-protection.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: sql injection, xss, injection protection, api gateway, flex gateway, gateway, policy
+:keywords: sql injection, xss, injection protection, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="1,3"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-ip-allowlist.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-ip-allowlist.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: ip, allowlist, validation, api gateway, flex gateway, gateway, policy
+:keywords: ip, allowlist, validation, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::ip-allowlist.adoc, policies::policies-included-ip-allowlist.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-ip-blocklist.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-ip-blocklist.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: ip, blocklist, validation, api gateway, flex gateway, gateway, policy
+:keywords: ip, blocklist, validation, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::ip-blocklist.adoc, policies::policies-included-ip-blocklist.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-json-threat-protection.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-json-threat-protection.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: json threat protection, api gateway, flex gateway, gateway, policy
+:keywords: json threat protection, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::apply-configure-json-threat-task.adoc, policies::policies-included-json-threat-protection.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-jwt-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-jwt-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: jwt validation, api gateway, flex gateway, gateway, policy
+:keywords: jwt validation, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::policy-mule4-jwt-validation.adoc, policies::policies-included-jwt-validation.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-llm-pii-detection.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-llm-pii-detection.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, llm, pii, personally identifiable information
+:keywords: api gateway, omni gateway, gateway, policy, llm, pii, personally identifiable information
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-llm-token-rate-limit.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-llm-token-rate-limit.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, rate limiting, token, llm, openai
+:keywords: api gateway, omni gateway, gateway, policy, rate limiting, token, llm, openai
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-attribute-access-control.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-attribute-access-control.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-global-access.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-global-access.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, mcp, global access
+:keywords: api gateway, omni gateway, gateway, policy, mcp, global access
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-payload-optimization.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-payload-optimization.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-pii-detector.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-pii-detector.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-progressive-disclosure.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-progressive-disclosure.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, mcp, progressive disclosure, tool search
+:keywords: api gateway, omni gateway, gateway, policy, mcp, progressive disclosure, tool search
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-support.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-support.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-mcp-tool-mapping.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-mcp-tool-mapping.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, mcp, tool mapping
+:keywords: api gateway, omni gateway, gateway, policy, mcp, tool mapping
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-message-logging.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-message-logging.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: message logging, api gateway, flex gateway, gateway, policy
+:keywords: message logging, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::message-logging-policy.adoc, policies::policies-included-message-logging.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-oauth-protected-resource-metadata.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-oauth-protected-resource-metadata.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: oauth, protected resource, metadata, rfc 9728, api gateway, flex gateway, gateway, policy
+:keywords: oauth, protected resource, metadata, rfc 9728, api gateway, omni gateway, gateway, policy
 :page-aliases: policies::policies-included-oauth-protected-resource-metadata.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-openid-token-enforcement.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-openid-token-enforcement.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: open, id, oauth 2.0, token, enforcement, api gateway, flex gateway, gateway, policy
+:keywords: open, id, oauth 2.0, token, enforcement, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::policy-openid-connect.adoc, policies::policies-included-openid-token-enforcement.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-rate-limiting-sla.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-rate-limiting-sla.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: rate-limiting sla, api gateway, flex gateway, gateway, policy
+:keywords: rate-limiting sla, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::rate-limiting-sla-policy.adoc, api-manager::rate-limiting-and-throttling-sla-based-policies.adoc, api-manager::tutorial-manage-an-api.adoc, policies::policies-included-rate-limiting-sla.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-rate-limiting.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-rate-limiting.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: rate limiting, api gateway, flex gateway, gateway, policy
+:keywords: rate limiting, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::rate-limiting.adoc, api-manager::rate-limiting-and-throttling.adoc, api-manager::to-configure-provider-multiple-workers.adoc, policies::policies-included-rate-limiting.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-regex-prompt-guard.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-regex-prompt-guard.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, llm, prompt guard, regex, prompt injection
+:keywords: api gateway, omni gateway, gateway, policy, llm, prompt guard, regex, prompt injection
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-response-timeout.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-response-timeout.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: oas3, schema validation, api gateway, flex gateway, gateway, policy
+:keywords: oas3, schema validation, api gateway, omni gateway, gateway, policy
 :page-aliases: policies::policies-included-schema-validation.adoc
 
 [width="100%", cols="5,15"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-soap-schema-validation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-soap-schema-validation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: xml threat protection, api gateway, flex gateway, gateway, policy 
+:keywords: xml threat protection, api gateway, omni gateway, gateway, policy 
 
 [width="100%", cols="1,3"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-spike-control.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-spike-control.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: spike control, api gateway, flex gateway, gateway, policy
+:keywords: spike control, api gateway, omni gateway, gateway, policy
 :page-aliases: api-manager::spike-control-reference.adoc, policies::policies-included-spike-control.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-sse-logging.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-sse-logging.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy
+:keywords: api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-stream-idle-timeout.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-stream-idle-timeout.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-tls-outbound.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-tls-outbound.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: tls, mtls, transport layer security, outbound tls, api gateway, flex gateway, gateway, policy
+:keywords: tls, mtls, transport layer security, outbound tls, api gateway, omni gateway, gateway, policy
 :page-aliases: policies::policies-included-tls-outbound.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-tls.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-tls.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: tls, mtls, transport layer security, inbound tls, api gateway, flex gateway, gateway, policy
+:keywords: tls, mtls, transport layer security, inbound tls, api gateway, omni gateway, gateway, policy
 :page-aliases: policies::policies-included-tls.adoc
 
 [%autowidth.spread,cols="a,a"]

--- a/gateway/1.13/modules/ROOT/pages/policies-included-tracing.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-tracing.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, otel, otel support, OpenTelemetry, distributed tracing
+:keywords: api gateway, omni gateway, gateway, policy, otel, otel support, OpenTelemetry, distributed tracing
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-websocket-connection-limit.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-websocket-connection-limit.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: websocket, connection limit, api gateway, flex gateway, gateway, policy
+:keywords: websocket, connection limit, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-included-xml-threat-protection.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-included-xml-threat-protection.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: xml threat protection, api gateway, flex gateway, gateway, policy 
+:keywords: xml threat protection, api gateway, omni gateway, gateway, policy 
 
 [width="100%", cols="1,3"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-mcp-access-control-together.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-mcp-access-control-together.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, mcp, access control, tool mapping, abac
+:keywords: api gateway, omni gateway, gateway, policy, mcp, access control, tool mapping, abac
 
 Omni Gateway provides three MCP policies that work together to control which tools and related MCP entities are exposed:
 

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-a2a-intask-authorization-code.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-a2a-intask-authorization-code.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api gateway, flex gateway, gateway, policy, a2a, authentication, oauth2, outbound
+:keywords: api gateway, omni gateway, gateway, policy, a2a, authentication, oauth2, outbound
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-api-key.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-api-key.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: api key, client credentials, authentication, api gateway, flex gateway, gateway, policy
+:keywords: api key, client credentials, authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-aws-signature.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-aws-signature.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: aws signature, aws request signing, authentication, api gateway, flex gateway, gateway, policy
+:keywords: aws signature, aws request signing, authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-basic-auth.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-basic-auth.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-jwt-generation.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-jwt-generation.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: jwt, token, authentication, api gateway, flex gateway, gateway, policy
+:keywords: jwt, token, authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-message-logging.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-message-logging.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: outbound message logging, api gateway, flex gateway, gateway, policy
+:keywords: outbound message logging, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-oauth-obo.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-oauth-obo.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: oauth2, token exchange, on-behalf-of, obo, rfc 8693, api gateway, flex gateway, gateway, policy
+:keywords: oauth2, token exchange, on-behalf-of, obo, rfc 8693, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-oauth.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-oauth.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===

--- a/gateway/1.13/modules/ROOT/pages/policies-outbound-upstream-idle-timeout.adoc
+++ b/gateway/1.13/modules/ROOT/pages/policies-outbound-upstream-idle-timeout.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images
-:keywords: basic authentication, api gateway, flex gateway, gateway, policy
+:keywords: basic authentication, api gateway, omni gateway, gateway, policy
 
 [width="100%", cols="5,15"]
 |===


### PR DESCRIPTION
## Summary
Renames customer-facing references to "Flex Gateway" to "Omni Gateway" in the gateway/1.13 directory.

## Changes
- Updated keywords metadata across 74 policy files
- Updated GraphQL Schema Validation policy content where "Flex Gateway automatically loads..." appeared

## Preserved (as requested)
- "(formally Flex Gateway)" references in index.adoc and other locations
- Code examples (Jenkins stage names like "Register flex gateway")
- Repository configurations (e.g., `name = Anypoint Flex Gateway`)
- Code comments

## Test plan
- [ ] Review changes to ensure proper updates
- [ ] Verify documentation builds successfully
- [ ] Confirm no broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)